### PR TITLE
FIX: Add Crystal Felling Axe

### DIFF
--- a/src/main/java/eu/jodelahithit/Constants.java
+++ b/src/main/java/eu/jodelahithit/Constants.java
@@ -147,7 +147,8 @@ public class Constants {
             WOODCUTTING_2H_ADAMANT,
             WOODCUTTING_2H_RUNE,
             WOODCUTTING_2H_DRAGON,
-            WOODCUTTING_2H_3A
+            WOODCUTTING_2H_3A,
+            WOODCUTTING_2H_CRYSTAL
     );
 
     static final Set<Integer> FLETCHING_ANIMATIONS = ImmutableSet.of(


### PR DESCRIPTION
**Issue**: The Crystal Felling Axe wasn't removing any notification overlay

**Fix**: Simply added the Crystal Felling Axe to the set of woodcutting animations